### PR TITLE
Fix argument check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 _No documentation available about unreleased changes as of yet._
 
+## [1.2.0] Update bootstrap
+
+### Changed
+- Fixed the `--group=integration` check in the bootstrap
+  - Before it depended on the position of the argument, so in PhpStorm running tests
+    failed because the argument wasn't in the second place. 
+
 ## [1.1.0] Update base test case
 
 ### Changed
@@ -19,5 +26,6 @@ _No documentation available about unreleased changes as of yet._
 - Added the functionality for the WordPress integration tests with PestPHP package.
 
 [Unreleased]: https://github.com/dingo-d/wp-pest-integration-test-setup/compare/main...HEAD
+[1.1.0]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/cadf3ac...1.0.0

--- a/templates/bootstrap-plugin.php.tmpl
+++ b/templates/bootstrap-plugin.php.tmpl
@@ -12,7 +12,7 @@ require_once dirname(__FILE__, 2) . $ds . 'vendor' . $ds . 'autoload.php';
  * add additional argument to the test run command if you want to run
  * integration tests.
  */
-if (isset($GLOBALS['argv']) && isset($GLOBALS['argv'][1]) && strpos($GLOBALS['argv'][1], 'integration') !== false) {
+if (isset($GLOBALS['argv']) && in_array('--group=integration', $GLOBALS['argv'], true)) {
 	if (!file_exists(dirname(__FILE__, 2) . '/wp/tests/phpunit/wp-tests-config.php')) {
 		// We need to set up core config details and test details
 		copy(

--- a/templates/bootstrap-theme.php.tmpl
+++ b/templates/bootstrap-theme.php.tmpl
@@ -12,7 +12,7 @@ require_once dirname(__FILE__, 2) . $ds . 'vendor' . $ds . 'autoload.php';
  * add additional argument to the test run command if you want to run
  * integration tests.
  */
-if (isset($GLOBALS['argv']) && isset($GLOBALS['argv'][1]) && strpos($GLOBALS['argv'][1], 'integration') !== false) {
+if (isset($GLOBALS['argv']) && in_array('--group=integration', $GLOBALS['argv'], true)) {
 	if (!file_exists(dirname(__FILE__, 2) . '/wp/tests/phpunit/wp-tests-config.php')) {
 		// We need to set up core config details and test details
 		copy(


### PR DESCRIPTION
The check whether to load the WordPress part of the bootstrap process failed in PhpStorm, because the command that is running in the IDE is something like

```bash
/opt/homebrew/opt/php@7.4/bin/php .../vendor/pestphp/pest/bin/pest --teamcity --group=integration --configuration .../phpunit.xml
```

Because PhpStorm injects the `--teamcity` option to the pest command the `--group=integration` argument wasn't in the second place so the check for 

```php
isset($GLOBALS['argv'][1]) && strpos($GLOBALS['argv'][1], 'integration') !== false
```

Failed.

The proposed PR fixes that issue by just checking the array for the argument.